### PR TITLE
Create new search using wego api

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ searching for hotels. The Locations API allows you to lookup text queries like
 Wego::Location.find "sydney"
 ```
 
+### Search
+
+To perform a real-time search on Wego's partners' sites for rates in a given
+location and date range, you need to pass the search terms with the user's ip.
+For example: create new search for hotels in Sydney (location ID 7046)
+
+```ruby
+Wego::Search.create(
+  location_id: "7046",
+  check_in: "2016-05-20",
+  check_out: "2016-05-25",
+  user_ip: "127.0.0.1"
+)
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies.

--- a/lib/wego.rb
+++ b/lib/wego.rb
@@ -1,6 +1,7 @@
 require "wego/version"
 require "wego/client"
 require "wego/location"
+require "wego/search"
 
 module Wego
 end

--- a/lib/wego/search.rb
+++ b/lib/wego/search.rb
@@ -1,0 +1,7 @@
+module Wego
+  class Search
+    def self.create(search_terms)
+      Wego::Client.new("search/new", search_terms).get
+    end
+  end
+end

--- a/spec/fixtures/search.json
+++ b/spec/fixtures/search.json
@@ -1,0 +1,5 @@
+{
+  "search_id": 71537475,
+  "is_done": false,
+  "created_at": "18-05-2016 12:29:12 SGT"
+}

--- a/spec/support/fake_wego_api.rb
+++ b/spec/support/fake_wego_api.rb
@@ -4,6 +4,11 @@ module FakeWegoApi
       to_return(response_with(file: "locations", status: 200))
   end
 
+  def stub_new_search_api(search_terms)
+    stub_request(:get, api_path("search/new", search_terms)).
+      to_return(response_with(file: "search", status: 200))
+  end
+
   private
 
   def api_path(end_point, attributes = {})

--- a/spec/wego/search_spec.rb
+++ b/spec/wego/search_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe Wego::Search do
+  it "create new search" do
+    search_terms = {
+      location_id: "7046",
+      check_in: "2016-05-20",
+      check_out: "2016-05-25",
+      user_ip: "127.0.0.1"
+    }
+
+    stub_new_search_api(search_terms)
+    search = Wego::Search.create(search_terms)
+
+    expect(search.search_id).not_to be_nil
+    expect(search.is_done).to be_falsey
+    expect(search.created_at).not_to be_nil
+  end
+end


### PR DESCRIPTION
User can create new search using wego api, they need to provide a valid `location id`, `check_in` date, `check_out` date along with `user_ip`. Once the search is created then the api will return the search id with search completion status.