### PR TITLE
Support active model serializers

### DIFF
--- a/lib/wego/response.rb
+++ b/lib/wego/response.rb
@@ -1,7 +1,11 @@
 module Wego
   class Response
     def self.parse_json(response)
-      JSON.parse(response, object_class: OpenStruct)
+      JSON.parse(response, object_class: Wego::OpenStruct)
     end
+  end
+
+  class OpenStruct < ::OpenStruct
+    alias :read_attribute_for_serialization :send
   end
 end

--- a/spec/wego/response_spec.rb
+++ b/spec/wego/response_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+describe Wego::Response do
+  describe ".parse_json" do
+    it "parses json response" do
+      content = File.read "./spec/fixtures/locations.json"
+      response = Wego::Response.parse_json(content)
+
+      expect(response.count).to eq(3)
+      expect(response.class).to be Wego::OpenStruct
+    end
+  end
+end


### PR DESCRIPTION
Most of the practical use cases scenario require response to be serilizable but our response object doesn't support as it should have. So let's change it to support one of the most popular gem `active_model_serializers`