### PR TITLE
Don't break down for bad requests

### DIFF
--- a/lib/wego/client.rb
+++ b/lib/wego/client.rb
@@ -35,6 +35,6 @@ module Wego
     Wego::Response.parse_json(
       Client.new(end_point, api_params).get
     )
-  rescue RestClient::ResourceNotFound
+  rescue RestClient::ResourceNotFound, RestClient::BadRequest
   end
 end

--- a/spec/wego/client_spec.rb
+++ b/spec/wego/client_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe Wego, ".get_resource" do
       expect(Wego.get_resource("invalid/resource")).to be_nil
     end
   end
+
+  context "when user submit invalid data" do
+    it "simple ignore it and returns nil" do
+      stub_invalid_api_response(status: 400)
+      expect(Wego.get_resource("invalid/resource")).to be_nil
+    end
+  end
 end
 
 RSpec.describe Wego::Client, "#raw url" do


### PR DESCRIPTION
When there is some required parameter missing then wego response with 400 status. This causing break down the as we only rescued `ResourceNotFound`, Let's change it to rescue `RestClient::BadRequest` as well.