### PR TITLE
Don't force user to format date

### DIFF
--- a/lib/wego/search.rb
+++ b/lib/wego/search.rb
@@ -3,7 +3,14 @@ require "wego/result"
 module Wego
   class Search
     def self.create(search_terms)
+      search_terms[:check_in] = Wego.format_date(search_terms[:check_in])
+      search_terms[:check_out] = Wego.format_date(search_terms[:check_out])
+
       Wego.get_resource "search/new", search_terms
     end
+  end
+
+  def self.format_date(date)
+    DateTime.parse(date).strftime("%Y-%m-%d")
   end
 end

--- a/lib/wego/version.rb
+++ b/lib/wego/version.rb
@@ -1,3 +1,3 @@
 module Wego
-  VERSION = "0.0.1".freeze
+  VERSION = "0.0.9".freeze
 end

--- a/spec/wego/search_spec.rb
+++ b/spec/wego/search_spec.rb
@@ -19,5 +19,22 @@ describe Wego::Search do
       expect(search.is_done).to be_falsey
       expect(search.created_at).not_to be_nil
     end
+
+    context "when date time provided" do
+      it "formats as required" do
+        stub_new_search_api(
+          location_id: "7046", check_in: "2016-05-23",
+          check_out: "2016-05-28", user_ip: "127.0.0.1"
+        )
+
+        search = Wego::Search.create(
+          location_id: "7046", check_in: "2016-05-23 15:05:21 UTC",
+          check_out: "28 May 2016, 15:05:21 UTC", user_ip: "127.0.0.1"
+        )
+
+        expect(search).not_to be_nil
+        expect(search.is_done).to be_falsey
+      end
+    end
   end
 end


### PR DESCRIPTION
Wego require date to be in specific format to create a new search. Currently we are relying on user to format the date properly, but it might be easier if we allow user to pass any date/datetime and we'll do the require formatting