### PR TITLE
Simplify booking link retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ using the API you can take users to continue the booking process at one of
 their partners' sites.
 
 ```ruby
-Wego::Booking.new(search_id: search_id, hotel_id: hotel_id, room_rate_id: rate_id).redirect_url
+Wego::Booking.url_for search_id, hotel_id: hotel_id, room_rate_id: room_rate_id
 ```
 
 ## Development

--- a/lib/wego/booking.rb
+++ b/lib/wego/booking.rb
@@ -1,25 +1,11 @@
 module Wego
   class Booking
-    attr_reader :search_id, :hotel_id, :room_rate_id
-
-    def initialize(attrs)
-      @search_id  = attrs[:search_id]
-      @hotel_id   = attrs[:hotel_id]
-      @room_rate_id = attrs[:room_rate_id]
-    end
-
-    def redirect_url
-      resource.raw_url
-    end
-
-    private
-
-    def resource
-      @resource ||= Wego::Client.new(
+    def self.url_for(search_id, hotel_id:, room_rate_id:)
+      Wego::Client.new(
         "search/redirect/#{search_id}",
         hotel_id: hotel_id,
         room_rate_id: room_rate_id
-      )
+      ).url
     end
   end
 end

--- a/lib/wego/client.rb
+++ b/lib/wego/client.rb
@@ -15,7 +15,7 @@ module Wego
       RestClient.get api_path, params: api_params
     end
 
-    def raw_url
+    def url
       params = api_params.map { |key, value| "#{key}=#{value}" }.join("&")
       [api_path, params].join("?")
     end

--- a/spec/wego/booking_spec.rb
+++ b/spec/wego/booking_spec.rb
@@ -3,14 +3,12 @@ require "spec_helper"
 describe Wego::Booking do
   describe "#redirect_url" do
     it "prepares the redirect url" do
-      booking = Wego::Booking.new(
-        search_id: 716_073_46,
-        hotel_id: 273_451,
-        room_rate_id: 12
+      booking_url = Wego::Booking.url_for(
+        716_073_46, hotel_id: 273_451, room_rate_id: 12
       )
 
-      expect(booking.redirect_url).to include("search/redirect/71607346?")
-      expect(booking.redirect_url).to include("hotel_id=273451&room_rate_id=12")
+      expect(booking_url).to include("search/redirect/71607346?")
+      expect(booking_url).to include("hotel_id=273451&room_rate_id=12")
     end
   end
 end

--- a/spec/wego/client_spec.rb
+++ b/spec/wego/client_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe Wego, ".get_resource" do
   end
 end
 
-RSpec.describe Wego::Client, "#raw url" do
+RSpec.describe Wego::Client, "#url" do
   it "reutns the url with serialized params" do
     attrs = { location: "dhaka" }
     resource = Wego::Client.new("/custom", attrs)
 
-    expect(resource.raw_url).to include("/custom?#{wego_api_path(attrs)}")
+    expect(resource.url).to include("/custom?#{wego_api_path(attrs)}")
   end
 
   def wego_api_path(options = {})


### PR DESCRIPTION
Existing wego booking link retrieval procedure was to create an instance and then retrieve the redirect url, which does not even force for required parameters. Let's simplify it and make necessary parameters mandatory.