### PR TITLE
Support multiple ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.1
+  - 2.2.0
+  - 2.1.9
 before_install: gem install bundler -v 1.12.2


### PR DESCRIPTION
Currently, we are running our specs using Ruby 2.3.1, but we think it's better to support all officially supported version, so we are starting to support version 2.3.1, 2.2.0 and 2.1.9