### PR TITLE
Add RSpec test related helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ After checking out the repo, run `bin/setup` to install dependencies.
 Then, run `rake spec` to run the tests. You can also run `bin/console` for an
 interactive prompt that will allow you to experiment.
 
+## Testing
+
+### RSpec
+
+This gem provides an easier way to test Wego API Responses. Simply include the
+following line in your `spec_helper` and you should have access to all of the
+test helpers.
+
+```ruby
+require "wego/rspec"
+```
 
 ## Contributing
 

--- a/lib/wego/rspec.rb
+++ b/lib/wego/rspec.rb
@@ -1,0 +1,5 @@
+require File.expand_path("../../../spec/support/fake_wego_api", __FILE__)
+
+RSpec.configure do |config|
+  config.include FakeWegoApi
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,9 @@
 require "webmock/rspec"
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require "wego"
-
-Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
+require "wego/rspec"
 
 RSpec.configure do |config|
-  config.include FakeWegoApi
-
   config.before :suite do
     Wego.configure do |wego_config|
       wego_config.api_key  = "WEGO_API_KEY"

--- a/spec/support/fake_wego_api.rb
+++ b/spec/support/fake_wego_api.rb
@@ -39,6 +39,9 @@ module FakeWegoApi
   end
 
   def fixture_file(filename)
-    File.read "./spec/fixtures/#{filename}.json"
+    file_name = [filename, "json"].join(".")
+    file_path = ["../../fixtures", file_name].join("/")
+
+    File.read(File.expand_path(file_path, __FILE__))
   end
 end


### PR DESCRIPTION
We don't want client application to do actual API requests while they are testing their application. This changes will provide an easier way to include API responses stubbing helpers.