### PR TITLE
Add spec support files to the gem

### DIFF
--- a/lib/wego/version.rb
+++ b/lib/wego/version.rb
@@ -1,3 +1,3 @@
 module Wego
-  VERSION = "0.1.1".freeze
+  VERSION = "0.1.2".freeze
 end

--- a/wego.gemspec
+++ b/wego.gemspec
@@ -13,9 +13,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://www.wan.travel/api"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files`.split("\n")
   spec.require_paths = ["lib"]
   spec.test_files    = `git ls-files -- {spec}/*`.split("\n")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.1.9")
 
   spec.add_dependency "rest-client", "~> 1.8"
 


### PR DESCRIPTION
Why:

Wego API response related helpers and fixtures are present in the spec directory, so let's update `wego.gemspec` to include those support files

We are also using hash arguments which was available since Ruby 2.1.9 so let's also set that as minimum required Ruby version