### PR TITLE
Enforce required search params

### DIFF
--- a/lib/wego/search.rb
+++ b/lib/wego/search.rb
@@ -2,11 +2,15 @@ require "wego/result"
 
 module Wego
   class Search
-    def self.create(search_terms)
-      search_terms[:check_in] = Wego.format_date(search_terms[:check_in])
-      search_terms[:check_out] = Wego.format_date(search_terms[:check_out])
-
-      Wego.get_resource "search/new", search_terms
+    def self.create(location_id:, check_in:, check_out:, user_ip:, **options)
+      Wego.get_resource(
+        "search/new",
+        location_id: location_id,
+        check_in: Wego.format_date(check_in),
+        check_out: Wego.format_date(check_out),
+        user_ip: user_ip,
+        **options
+      )
     end
   end
 


### PR DESCRIPTION
Creating a new search require `location_id`, `check_in` `check_out` and `user_ip`. But current search interface doesn't enforce user to provide those params, which is creating unnecessary API call.

This commit change the search creating interface to the hash arguments, which will ensure required parameters are present before doing any API request.