### PR TITLE
Add support for booking options

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ their partners' sites.
 
 ```ruby
 Wego::Booking.url_for(
-  search_id, hotel_id: hotel_id, room_rate_id: room_rate_id
+  search_id, hotel_id: hotel_id, room_rate_id: room_rate_id, locale: "en"
 )
 ```
 

--- a/lib/wego/booking.rb
+++ b/lib/wego/booking.rb
@@ -1,10 +1,11 @@
 module Wego
   class Booking
-    def self.url_for(search_id, hotel_id:, room_rate_id:)
+    def self.url_for(search_id, hotel_id:, room_rate_id:, **options)
       Wego::Client.new(
         "search/redirect/#{search_id}",
         hotel_id: hotel_id,
-        room_rate_id: room_rate_id
+        room_rate_id: room_rate_id,
+        **options
       ).url
     end
   end

--- a/lib/wego/version.rb
+++ b/lib/wego/version.rb
@@ -1,3 +1,3 @@
 module Wego
-  VERSION = "0.1.4".freeze
+  VERSION = "0.1.5".freeze
 end

--- a/spec/wego/booking_spec.rb
+++ b/spec/wego/booking_spec.rb
@@ -4,11 +4,15 @@ describe Wego::Booking do
   describe "#redirect_url" do
     it "prepares the redirect url" do
       booking_url = Wego::Booking.url_for(
-        716_073_46, hotel_id: 273_451, room_rate_id: 12
+        716_073_46,
+        hotel_id: 273_451,
+        room_rate_id: 12,
+        locale: "en",
+        currency_code: "GBP"
       )
 
       expect(booking_url).to include("search/redirect/71607346?")
-      expect(booking_url).to include("hotel_id=273451&room_rate_id=12")
+      expect(booking_url).to include("hotel_id=273451&room_rate_id=12&locale")
     end
   end
 end


### PR DESCRIPTION
Current booking interface only usages the default options to build the redirection url, it doesn't have any support for additional options that is offered by Wego API

This commit adds the support for additional options params. Developer can use it to keep user preference while they're redirecting them to the wego's partners site