### PR TITLE
Fix all of the failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.1
-  - 2.2.0
-  - 2.1.9
+  - 2.6.5
+  - 2.5.0
+  - 2.4.0
 before_install: gem install bundler -v 1.12.2

--- a/lib/wego/client.rb
+++ b/lib/wego/client.rb
@@ -27,7 +27,7 @@ module Wego
     end
 
     def api_params
-      Wego.configuration.api_keys.merge attributes
+      Wego.configuration.api_keys.merge(attributes).compact
     end
   end
 

--- a/spec/support/fake_wego_api.rb
+++ b/spec/support/fake_wego_api.rb
@@ -14,7 +14,7 @@ module FakeWegoApi
   def stub_search_result_api(search_id:, hotel_id:, **options)
     stub_api_response(
       "search/#{search_id}",
-      options.merge(hotel_id: hotel_id),
+      options.merge(hotel_id: hotel_id).compact,
       filename: "result"
     )
   end

--- a/spec/wego/client_spec.rb
+++ b/spec/wego/client_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Wego::Client, "#url" do
   end
 
   def wego_api_path(options = {})
-    params = Wego.configuration.api_keys.merge(options)
+    params = Wego.configuration.api_keys.merge(options).compact
     params.map { |key, value| "#{key}=#{value}" }.join("&")
   end
 end

--- a/wego.gemspec
+++ b/wego.gemspec
@@ -16,11 +16,11 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split("\n")
   spec.require_paths = ["lib"]
   spec.test_files    = `git ls-files -- {spec}/*`.split("\n")
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.1.9")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.add_dependency "rest-client", "~> 2.0"
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 2.3"


### PR DESCRIPTION
The recent version of the rest-client has some changes, which is formatting the parameters different than the earlier versions, and this is what was causing some test failures. This commit update those tests with the correct format.